### PR TITLE
Fix error: use of deleted function

### DIFF
--- a/browedit/Menu_Actions.cpp
+++ b/browedit/Menu_Actions.cpp
@@ -176,7 +176,7 @@ void BrowEdit::menuActionsLightmapCalculate()
 
 
 	std::vector<std::thread> threads;
-	std::atomic<unsigned>    finishedX = 0;
+	std::atomic<unsigned> finishedX(0);
 	for (int t = 0; t < 8; t++)
 	{
 		threads.push_back(std::thread([&]()


### PR DESCRIPTION
`Menu_Actions.cpp:179:50: error: use of deleted function ‘std::atomic<int>::atomic(const std::atomic<int>&)’`

It was using delete to initialize finishedX.

